### PR TITLE
use `github.com/gobwas/glob` to match path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/paulfantom/periodic-labeler
 go 1.12
 
 require (
+	github.com/gobwas/glob v0.2.3
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-github/v28 v28.1.1
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -17,6 +19,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0Is3p+EHBKNgquIzo1OI=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -45,8 +45,11 @@ func matchFiles(labelsMatch map[string][]glob.Glob, files []*github.CommitFile) 
 	set := make(map[string]bool)
 	for _, file := range files {
 		for label, matchers := range labelsMatch {
+			if set[label] {
+				continue
+			}
 			for _, m := range matchers {
-				if match := m.Match(*file.Filename); match && !set[label] {
+				if m.Match(*file.Filename) {
 					set[label] = true
 					labelSet = append(labelSet, label)
 					break

--- a/main.go
+++ b/main.go
@@ -58,24 +58,24 @@ func matchFiles(labelsMatch map[string][]glob.Glob, files []*github.CommitFile) 
 }
 
 func buildLabelMatchers(from string) (map[string][]glob.Glob, error) {
-	var labelerConfig map[string][]string
-	if err := yaml.Unmarshal([]byte(from), &labelerConfig); err != nil {
+	var config map[string][]string
+	if err := yaml.Unmarshal([]byte(from), &config); err != nil {
 		return nil, err
 	}
 
-	labelMatchers := make(map[string][]glob.Glob, len(labelerConfig))
+	matchers := make(map[string][]glob.Glob, len(config))
 
-	for labelName, patterns := range labelerConfig {
-		for _, pattern := range patterns {
-			m, err := glob.Compile(pattern)
+	for label, patterns := range config {
+		for _, p := range patterns {
+			m, err := glob.Compile(p)
 			if err != nil {
 				return nil, err
 			}
-			labelMatchers[labelName] = append(labelMatchers[labelName], m)
+			matchers[label] = append(matchers[label], m)
 		}
 	}
 
-	return labelMatchers, nil
+	return matchers, nil
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -12,10 +12,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type matcher interface {
-	Match(string) bool
-}
-
 func contains(slice []string, item string) bool {
 	set := make(map[string]struct{}, len(slice))
 	for _, s := range slice {
@@ -44,7 +40,7 @@ func containsLabels(expected []string, current []string) bool {
 }
 
 // Get files and labels matchers, output labels
-func matchFiles(labelsMatch map[string][]matcher, files []*github.CommitFile) []string {
+func matchFiles(labelsMatch map[string][]glob.Glob, files []*github.CommitFile) []string {
 	var labelSet []string
 	set := make(map[string]bool)
 	for _, file := range files {
@@ -61,13 +57,13 @@ func matchFiles(labelsMatch map[string][]matcher, files []*github.CommitFile) []
 	return labelSet
 }
 
-func buildLabelMatchers(from string) (map[string][]matcher, error) {
+func buildLabelMatchers(from string) (map[string][]glob.Glob, error) {
 	var labelerConfig map[string][]string
 	if err := yaml.Unmarshal([]byte(from), &labelerConfig); err != nil {
 		return nil, err
 	}
 
-	labelMatchers := make(map[string][]matcher, len(labelerConfig))
+	labelMatchers := make(map[string][]glob.Glob, len(labelerConfig))
 
 	for labelName, patterns := range labelerConfig {
 		for _, pattern := range patterns {

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func buildLabelMatchers(from string) (map[string][]glob.Glob, error) {
 
 	for label, patterns := range config {
 		for _, p := range patterns {
-			m, err := glob.Compile(p)
+			m, err := glob.Compile(p, '/')
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes: #7

This adds support for `**`

Pattern syntax:
> https://github.com/gobwas/glob/blob/e7a84e9525fe90abcda167b604e483cc959ad4aa/glob.go#L16-L37