### PR TITLE
Impove dockerbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
 
-FROM gcr.io/distroless/static
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/paulfantom/periodic-labeler/periodic-labeler /
 ENTRYPOINT ["/periodic-labeler"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as builder
+FROM golang:alpine as builder
 
 WORKDIR /go/src/github.com/paulfantom/periodic-labeler
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine as builder
 WORKDIR /go/src/github.com/paulfantom/periodic-labeler
 COPY . .
 
-RUN CGO_ENABLED=0 go build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s"
 
 FROM gcr.io/distroless/static
 COPY --from=builder /go/src/github.com/paulfantom/periodic-labeler/periodic-labeler /


### PR DESCRIPTION
This PR improves pull timings and result image size.

- `golang` => `golang:alpine`
- `gcr.io/distroless/static` => [`scratch`](https://hub.docker.com/_/scratch)
- do not include debug info into the binary (`-ldflags="-w -s"`)

Image size reduced from `10.3MB` to `6.47MB`, in details:

Before:

```console
118 ilyam:periodic-labeler (master %)$ docker images
REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
labeler                    latest              cd7d7b9d2e0f        3 seconds ago       10.3MB
<none>                     <none>              63cd54284b36        6 seconds ago       843MB
golang                     latest              297e5bf50f50        43 hours ago        803MB
gcr.io/distroless/static   latest              e4d2a899b1bf        50 years ago        1.82MB
```

After:

```console
113 ilyam:periodic-labeler (impove_dockerbuild %)$ docker images
REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
labeler                latest              b07c3d58e84e        4 seconds ago       6.47MB
<none>                 <none>              f20427892001        5 seconds ago       397MB
golang                 alpine              e1fd9820be16        43 hours ago        359MB
```